### PR TITLE
Allow 'reset' of time machine variable

### DIFF
--- a/dark-sky-api.js
+++ b/dark-sky-api.js
@@ -32,7 +32,7 @@ class DarkSky {
 
   time(time) {
     !truthyOrZero(time)
-      ? null
+      ? (this.t = null)
       : (this.t = moment(new Date(time)).format('YYYY-MM-DDTHH:mm:ss'))
     return this
   }


### PR DESCRIPTION
I have two calls that I need to make within a loop. One is a time machine request and the other is current/forecast.

I currently have no way to reset the time variable `this.t` and so all subsequent calls after the first iteration of the loop will unintentionally have be a time machine request.

This change allows me to sent a blank/null time.