### PR TITLE
Fix units query parameter name

### DIFF
--- a/dark-sky-api.js
+++ b/dark-sky-api.js
@@ -47,9 +47,9 @@ class DarkSky {
 
   units(unit) {
     if (unit) {
-      this.query.unit = unit
+      this.query.units = unit
     } else {
-      this.query.unit = null
+      this.query.units = null
     }
     return this
   }


### PR DESCRIPTION
To change units in the Dark Sky API, the "units" (plural) query parameter is used. This fixes the API so that the correct parameter name is used.

https://darksky.net/dev/docs#/dev/docs#api-request-types